### PR TITLE
Use done and fail in getJSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     </a>
 
     <!-- https://dev.twitter.com/docs/intents -->
-    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;via=test" class="share-twitter">
+    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;" class="share-twitter">
       <span class="icon icon-twitter" aria-hidden="true"></span>
       <span class="share-title">Tweet</span>
       <span class="share-count">0</span>
@@ -82,7 +82,7 @@
     </a>
 
     <!-- https://dev.twitter.com/docs/intents -->
-    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;via=test" class="share-twitter">
+    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;" class="share-twitter">
       <span class="icon icon-twitter" aria-hidden="true"></span>
       <span class="share-title">Tweet</span>
     </a>
@@ -122,7 +122,7 @@
     </a>
 
     <!-- https://dev.twitter.com/docs/intents -->
-    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;via=test" class="share-twitter">
+    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;" class="share-twitter">
       <span class="icon icon-twitter" aria-hidden="true"></span>
       <span class="share-title">Tweet</span>
       <span class="share-count">0</span>
@@ -164,7 +164,7 @@
     </a>
 
     <!-- https://dev.twitter.com/docs/intents -->
-    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;via=test" class="share-twitter">
+    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;" class="share-twitter">
       <span class="icon icon-twitter" aria-hidden="true"></span>
       <span class="share-title">Tweet</span>
       <span class="share-count">0</span>
@@ -204,7 +204,7 @@
     </a>
 
     <!-- https://dev.twitter.com/docs/intents -->
-    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;via=test" class="share-twitter">
+    <a target="_blank" href="http://twitter.com/share?url=http://labs.carsonshold.com/social-sharing-buttons&amp;text=jQuery%20social%20media%20buttons%20with%20share%20counts%20on%20GitHub&amp;" class="share-twitter">
       <span class="icon icon-twitter" aria-hidden="true"></span>
       <span class="share-title">Tweet</span>
     </a>

--- a/social-buttons.js
+++ b/social-buttons.js
@@ -29,33 +29,45 @@ CSbuttons.socialSharing = function () {
       $googleLink = $('.share-google');
 
   if ( $fbLink.length ) {
-    $.getJSON('https://graph.facebook.com/?id=' + permalink + '&callback=?', function(data) {
-      if (data.shares) {
-        $fbLink.find('.share-count').text(data.shares).addClass('is-loaded');
-      } else {
+    $.getJSON('https://graph.facebook.com/?id=' + permalink + '&callback=?')
+      .done(function(data) {
+        if (data.shares) {
+          $fbLink.find('.share-count').text(data.shares).addClass('is-loaded');
+        } else {
+          $fbLink.find('.share-count').remove();
+        }
+      })
+      .fail(function(data) {
         $fbLink.find('.share-count').remove();
-      }
-    });
+      });
   };
 
   if ( $twitLink.length ) {
-    $.getJSON('https://cdn.api.twitter.com/1/urls/count.json?url=' + permalink + '&callback=?', function(data) {
-      if (data.count > 0) {
-        $twitLink.find('.share-count').text(data.count).addClass('is-loaded');
-      } else {
+    $.getJSON('https://cdn.api.twitter.com/1/urls/count.json?url=' + permalink + '&callback=?')
+      .done(function(data) {
+        if (data.count > 0) {
+          $twitLink.find('.share-count').text(data.count).addClass('is-loaded');
+        } else {
+          $twitLink.find('.share-count').remove();
+        }
+      })
+      .fail(function(data) {
         $twitLink.find('.share-count').remove();
-      }
-    });
+      });
   };
 
   if ( $pinLink.length ) {
-    $.getJSON('https://api.pinterest.com/v1/urls/count.json?url=' + permalink + '&callback=?', function(data) {
-      if (data.count > 0) {
-        $pinLink.find('.share-count').text(data.count).addClass('is-loaded');
-      } else {
+    $.getJSON('https://api.pinterest.com/v1/urls/count.json?url=' + permalink + '&callback=?')
+      .done(function(data) {
+        if (data.count > 0) {
+          $pinLink.find('.share-count').text(data.count).addClass('is-loaded');
+        } else {
+          $pinLink.find('.share-count').remove();
+        }
+      })
+      .fail(function(data) {
         $pinLink.find('.share-count').remove();
-      }
-    });
+      });
   };
 
   if ( $googleLink.length ) {


### PR DESCRIPTION
Sometimes Twitter grabs the wrong number of shares. The URL it is grabbing from is right if you navigate to it directly, so I'm at a loss as to why. No current example of where it's wrong, but it happens - confirmed by @apautler.

This PR uses `.done` and `.fail` as `$.getJSON` callbacks instead of going straight to a function. From a technical standpoint this shouldn't fix the issue, but it is a nicer way to organize the callbacks. I also remove the `via` Twitter URL parameter as it's not too useful in this case.

