### PR TITLE
Fix Twitter Counter #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Simple social sharing buttons with shared count ajax lookups.
 ```
 sass --watch social-buttons.scss:social-buttons.css
 ```
+
+### Twitter Count
+
+For those that want the Twitter count back (as it was removed from the Twitter API), please make sure to register your website at [New Share Counts](http://newsharecounts.com/) as this is the alternative that our buttons now use.
+
+Your Twitter count may continue where you left off or start from `0`. Please refer to the linked website for more details.

--- a/social-buttons.js
+++ b/social-buttons.js
@@ -46,7 +46,7 @@ CSbuttons.socialSharing = function () {
   };
 
   if ( $twitLink.length ) {
-    $.getJSON('https://cdn.api.twitter.com/1/urls/count.json?url=' + permalink + '&callback=?')
+    $.getJSON('http://public.newsharecounts.com/count.json?url=' + permalink + '&callback=?')
       .done(function(data) {
         if (data.count > 0) {
           $twitLink.find('.share-count').text(data.count).addClass('is-loaded');


### PR DESCRIPTION
Twitter removed their counter from all share buttons. This change is based on the API from http://newsharecounts.com/

They count the new shares on their server so (for my site at least) the counter started from `0`, but I've tested it and it works fine.

They do mention:

> That's why we collected Twitter share counts for 1000000000 (yes, billion!) pages all around the Web before Twitter shut them down.  It's very likely that your share counts won't have to start from zero.

So for some sites it might not start from `0`. I did need to authorize their site for my account on twitter before though, I'm not sure if this is really needed or not, it may be that they do this by scraping the shares that are available on all the accounts that authenticated their site (but this is pure speculation).
